### PR TITLE
Remove jquery preload of menu images

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -90,8 +90,6 @@ $(function(){
 	 });
 
 
-
-	jQuery.preLoadImages("images/menu/menu-home-over.gif", "images/menu/menu-newresource-over.gif","images/menu/menu-myqueue-over.gif", "images/menu/menu-admin-over.gif", "images/menu/menu-end-over.gif");
 	 
 	 //for swapping menu images
 	$('.rollover').hover(function() {


### PR DESCRIPTION
The jquery preload of menu images, which were deleted when moving to css display, are causing 404 errors.
