### PR TITLE
Use currentEndDate instead of subscriptionEndDate to find needed alerts

### DIFF
--- a/admin/classes/domain/AlertDaysInAdvance.php
+++ b/admin/classes/domain/AlertDaysInAdvance.php
@@ -30,8 +30,8 @@ class AlertDaysInAdvance extends DatabaseObject {
 
 		$query = "SELECT DISTINCT resourceID
 					FROM Resource
-					WHERE ((DATE_SUB(subscriptionEndDate, INTERVAL " . $this->daysInAdvanceNumber . " DAY) = CURDATE()) OR
-					(subscriptionEndDate = CURDATE()))
+					WHERE ((DATE_SUB(currentEndDate, INTERVAL " . $this->daysInAdvanceNumber . " DAY) = CURDATE()) OR
+					(currentEndDate = CURDATE()))
 					AND subscriptionAlertEnabledInd = '1'";
 
 


### PR DESCRIPTION
The cost history enhancement in version 1.3 broke end-of-subscription alerts.  This change fixes them.