### PR TITLE
Feature enhancements to the resource routing tab

### DIFF
--- a/admin/emails/DeletedPriorStep.txt
+++ b/admin/emails/DeletedPriorStep.txt
@@ -1,0 +1,5 @@
+For resource: <ResourceTitle>
+
+The prior step has been deleted and now the resource is in your queue.
+
+Visit the record at <ResourceRecordURL><ResourceID>

--- a/admin/emails/ReassignedStep.txt
+++ b/admin/emails/ReassignedStep.txt
@@ -1,0 +1,5 @@
+For resource: <ResourceTitle>
+
+The step '<StepName>' has been reassigned to you. It is now in your queue.
+
+Visit the record at <ResourceRecordURL><ResourceID>

--- a/ajax_forms/getResourceStepForm.php
+++ b/ajax_forms/getResourceStepForm.php
@@ -1,0 +1,75 @@
+<?php
+if (!isset($_GET['resourceStepID'])){
+    echo "<div><p>You must supply a valid resource step ID.</p></div>";
+}else{
+    $resourceStepID = $_GET['resourceStepID'];
+    $resourceStep = new ResourceStep(new NamedArguments(array('primaryKey' => $resourceStepID)));
+    //get step name & group
+    $stepName = $resourceStep->attributes['stepName'];
+    $stepGroupID = $resourceStep->attributes['userGroupID'];
+    $orderNum = $resourceStep->attributes['displayOrderSequence'];
+    $remainingSteps = $resourceStep->getNumberOfOpenSteps();
+    //echo "the step name is ".$stepName.", and the group id is ". $stepGroup.".<br>\n";
+    //get possible groups
+    $userGroupArray = array();
+    $userGroupObj = new UserGroup();
+    $userGroupArray = $userGroupObj->allAsArray();
+
+    //make form
+    ?>
+    <div id='div_resourceStepForm'>
+        <form id='resourceStepForm'>
+            <input type='hidden' name='editRSID' id='editRSID' value='<?php echo $resourceStepID; ?>'>
+            <input type='hidden' name='orderNum' id='orderNum' value='<?php echo $orderNum; ?>'>
+            <input type='hidden' name='currentGroupID' id='currentGroupID' value='<?php echo $stepGroupID; ?>'>
+            <div class='formTitle' style='width:705px; margin-bottom:5px;position:relative;'><span class='headerText'>Edit Resource Step</span></div>
+
+            <span class='smallDarkRedText' id='span_errors'></span>
+
+            <table class='noBorder' style='width:100%;'>
+                <tr style='vertical-align:top;'>
+                    <td style='vertical-align:top;position:relative;'>
+                        <span class='surroundBoxTitle'>&nbsp;&nbsp;<label for='rule'><b>Reassign Resource Step</b></label>&nbsp;&nbsp;</span>
+
+                        <table class='surroundBox' style='width:700px;'>
+                            <tr>
+                                <td>
+                                    <table class='noBorder' style='width:660px; margin:15px 20px 10px 20px;'>
+                                        <tr>
+                                            <!--                                                <td>Step name: <pre>--><?php //var_dump($resourceStep); ?><!--</pre></td>-->
+                                            <td>Step name: <?php echo $stepName; ?></td>
+                                            <td style='vertical-align:top;text-align:left;'>
+                                                <label for='userGroupID'>Group: </label>
+                                                <select name='userGroupID' id='userGroupID' style='width:150px;' class='changeSelect userGroupID'>
+                                                    <?php
+
+                                                    foreach ($userGroupArray as $userGroup){
+                                                        $selected = ($userGroup['userGroupID']==$stepGroupID)? 'selected':'';
+                                                        echo "<option value='" . $userGroup['userGroupID'] . "' ".$selected.">" . $userGroup['groupName'] . "</option>\n";
+                                                    }
+                                                    ?>
+                                                </select>
+                                            </td>
+                                            <td><input name="applyToAll" id='applyToAll' type="checkbox">Apply to all later steps?</input></td>
+                                        </tr>
+                                    </table>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+
+            <table class='noBorderTable' style='width:125px;'>
+                <tr>
+                    <td style='text-align:left'><input type='button' value='submit' name='submitResourceStepForm' id ='submitResourceStepForm'></td>
+                    <td style='text-align:right'><input type='button' value='cancel' onclick="kill(); tb_remove();"></td>
+                </tr>
+            </table>
+
+            <script type="text/javascript" src="js/forms/resourceStepForm.js"></script>
+        </form>
+    </div>
+
+    <?php
+
+}

--- a/ajax_htmldata/getOutstandingQueue.php
+++ b/ajax_htmldata/getOutstandingQueue.php
@@ -14,7 +14,7 @@
 		?>
 
 
-			<table class='dataTable' style='width:646px;padding:0x;margin:0px;height:100%;'>
+			<table class='dataTable' style='width:646px;padding:0px;margin:0px;height:100%;'>
 			<tr>
 				<th style='width:45px;'>ID</th>
 				<th style='width:300px;'>Name</th>
@@ -43,7 +43,7 @@
 				$status = new Status(new NamedArguments(array('primaryKey' => $resource['statusID'])));
 
 		?>
-				<tr id='tr_<?php echo $resource['resourceID']; ?>' style='padding:0x;margin:0px;height:100%;'>
+				<tr id='tr_<?php echo $resource['resourceID']; ?>' style='padding:0px;margin:0px;height:100%;'>
 					<td <?php echo $classAdd; ?>><a href='resource.php?resourceID=<?php echo $resource['resourceID']; ?>'><?php echo $resource['resourceID']; ?></a></td>
 					<td <?php echo $classAdd; ?>><a href='resource.php?resourceID=<?php echo $resource['resourceID']; ?>'><?php echo $resource['titleText']; ?></a></td>
 					<td <?php echo $classAdd; ?>><?php echo $acquisitionType->shortName; ?></td>

--- a/ajax_htmldata/getRoutingDetails.php
+++ b/ajax_htmldata/getRoutingDetails.php
@@ -19,9 +19,11 @@
 			<table class='linedDataTable' style='width:100%;margin-bottom:5px;'>
 				<tr>
 				<th style='background-color:#dad8d8;width:350px;'>Step</th>
+				<th style='background-color:#dad8d8;'>&nbsp;</th>
 				<th style='background-color:#dad8d8;width:150px;'>Group</th>
 				<th style='background-color:#dad8d8;width:120px;'>Start Date</th>
 				<th style='background-color:#dad8d8;width:250px;'>Complete</th>
+				<th style='background-color:#dad8d8;'>Delete</th>
 				</tr>
 			<?php
 			$openStep=0;
@@ -39,6 +41,9 @@
 				?>
 				<tr>
 				<td <?php echo $classAdd; ?>><?php echo $resourceStep->stepName; ?></td>
+				<td <?php echo $classAdd; ?>><?php if (is_null_date($resourceStep->stepEndDate)){
+						echo '<a href="ajax_forms.php?action=getResourceStepForm&amp;resourceStepID='.$resourceStep->resourceStepID.'&amp;height=250&amp;width=750&amp;modal=true" class="thickbox"><img src="images/edit.gif" alt="edit" title="edit"></a>';
+					} ?></td>
 				<td <?php echo $classAdd; ?>><?php echo $userGroup->groupName; ?></td>
 				<td <?php echo $classAdd; ?>><?php if ($resourceStep->stepStartDate) { echo format_date($resourceStep->stepStartDate); } ?></td>
 				<td <?php echo $classAdd; ?>>
@@ -57,6 +62,12 @@
 						//track how many open steps there are
 						$openStep++;
 					}?>
+				</td>
+				<td style="text-align:center;"> <?php
+					//add a delete step option, there will be a modal confirmation before delete.
+					if (!$resourceStep->stepEndDate){
+						echo '<a href="javascript:void(0);" class="removeResourceStep" id="'. $resourceStep->resourceStepID .'"><img src="images/cross.gif" alt="delete" title="delete"></a>';
+					} ?>
 				</td>
 				</tr>
 				<?php

--- a/ajax_processing/deleteResourceStep.php
+++ b/ajax_processing/deleteResourceStep.php
@@ -1,0 +1,14 @@
+<?php
+$resourceStepID = $_GET['resourceStepID'];
+$resourceStep = new ResourceStep(new NamedArguments(array('primaryKey' => $resourceStepID)));
+
+try {
+    $resourceStep->delete();
+    $resourceStep->startNextStepsOrComplete();
+
+    //TODO fix the display order sequence if there are later steps
+
+
+} catch (Exception $e) {
+    echo $e->getMessage();
+}

--- a/ajax_processing/updateResourceStep.php
+++ b/ajax_processing/updateResourceStep.php
@@ -1,0 +1,34 @@
+<?php
+$resourceStepID = $_POST['resourceStepID'];
+$userGroupID = $_POST['userGroupID'];
+$applyToAll = ($_POST['applyToAll'] == "true")? true:false;
+
+
+if($resourceStepID != ''){
+    $step = new ResourceStep(new NamedArguments(array('primaryKey' => $resourceStepID)));
+
+    //business logic
+    $step->userGroupID = $userGroupID;
+
+    //if apply to all selected, we need to cycle through later steps.
+
+    try {
+        $step->restartReassignedStep();
+
+        if ($applyToAll){
+            //get later open steps and restart those.
+            $laterSteps = $step->getLaterOpenSteps();
+            if (count($laterSteps) > 0){
+                foreach($laterSteps as $laterStep){
+                    $laterStep->userGroupID = $userGroupID;
+                    $laterStep->restartReassignedStep();
+                }
+            }
+        }
+    } catch (Exception $e) {
+        echo $e->getMessage();
+    }
+}else{
+    //do something for empty result
+    echo "There was an error. Invalid or missing step.";
+}

--- a/js/forms/resourceStepForm.js
+++ b/js/forms/resourceStepForm.js
@@ -1,0 +1,155 @@
+/*
+ **************************************************************************************************************************
+ ** CORAL Resources Module v. 1.2
+ **
+ ** Copyright (c) 2015 North Carolina State University
+ **
+ ** This file is part of CORAL.
+ **
+ ** CORAL is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ **
+ ** CORAL is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU General Public License along with CORAL.  If not, see <http://www.gnu.org/licenses/>.
+ **
+ **************************************************************************************************************************
+ */
+
+$(document).ready(function(){
+
+
+    $("#submitResourceStepForm").click(function () {
+        updateResourceStep();
+
+        //# sourceURL=js/forms/resourceStepForm.js
+    });
+    //# sourceURL=js/forms/resourceStepForm.js
+
+
+    //do submit if enter is hit
+    $('#userGroupID').keyup(function(e) {
+        if(e.keyCode == 13) {
+            $('#submitResourceStepForm').click();
+        }
+    });
+
+
+    //the following are all to change the look of the inputs when they're clicked
+    $('.changeDefaultWhite').live('focus', function(e) {
+        if (this.value == this.defaultValue){
+            this.value = '';
+        }
+    });
+
+    $('.changeDefaultWhite').live('blur', function() {
+        if(this.value == ''){
+            this.value = this.defaultValue;
+        }
+    });
+
+
+    $('.changeInput').addClass("idleField");
+
+    $('.changeInput').live('focus', function() {
+
+
+        $(this).removeClass("idleField").addClass("focusField");
+
+        if(this.value != this.defaultValue){
+            this.select();
+        }
+
+    });
+
+
+    $('.changeInput').live('blur', function() {
+        $(this).removeClass("focusField").addClass("idleField");
+    });
+
+
+    $('.changeAutocomplete').live('focus', function() {
+        if (this.value == this.defaultValue){
+            this.value = '';
+        }
+
+    });
+
+
+    $('.changeAutocomplete').live('blur', function() {
+        if(this.value == ''){
+            this.value = this.defaultValue;
+        }
+    });
+
+
+
+
+    $('select').addClass("idleField");
+    $('select').live('focus', function() {
+        $(this).removeClass("idleField").addClass("focusField");
+
+    });
+
+    $('select').live('blur', function() {
+        $(this).removeClass("focusField").addClass("idleField");
+    });
+
+});
+
+function validateStep (){
+    //don't submit the form if it has the same usergroup.
+    if ($("#userGroupID").val() == $("#currentGroupID").val()){
+        return false;
+    };
+
+    return true;
+}
+
+function updateResourceStep(){
+
+    if (validateStep() === true) {
+        $('#submitResourceStepForm').attr("disabled", "disabled");
+        $.ajax({
+            type:       "POST",
+            url:        "ajax_processing.php?action=updateResourceStep",
+            cache:      false,
+            data:       { resourceStepID: $("#editRSID").val(), userGroupID: $("#userGroupID").val(), applyToAll: $('#applyToAll').is(':checked'), orderNum: $('#orderNum').val() },
+            success:    function(html) {
+                if (html){
+                    $("#span_errors").html(html);
+                }else{
+                    tb_remove();
+                    window.parent.updateRouting();
+                    //eval("window.parent.update" + $("#tab").val() + "();");
+                    return false;
+                }
+
+            }
+
+
+        });
+
+    }else{
+        tb_remove();
+        return true;
+    }
+
+}
+
+//kill all binds done by jquery live
+function kill(){
+
+    $('.addPayment').die('click');
+    $('.remove').die('click');
+    $('.changeAutocomplete').die('blur');
+    $('.changeAutocomplete').die('focus');
+    $('.changeDefault').die('blur');
+    $('.changeDefault').die('focus');
+    $('.changeInput').die('blur');
+    $('.changeInput').die('focus');
+    $('.select').die('blur');
+    $('.select').die('focus');
+
+}
+
+//# sourceURL=js/forms/resourceStepForm.js

--- a/js/resource.js
+++ b/js/resource.js
@@ -496,7 +496,6 @@ function bind_removes(){
    });
 
 
-
 }
 
 
@@ -552,7 +551,23 @@ function bind_routing(){
 	 }
    });
 
-   
+   $(".removeResourceStep").unbind('click').click(function () {
+        if (confirm("Do you really want to delete this step? If other steps depended on this one, they will be started upon deletion. This action cannot be undone") == true) {
+            $.ajax({
+                type:       "GET",
+                url:        "ajax_processing.php",
+                cache:      false,
+                data:       "action=deleteResourceStep&resourceStepID=" + $(this).attr("id"),
+                success:    function(html) {
+                    updateRouting();
+                }
+
+
+            });
+        }
+
+   });
+
 }
 
 

--- a/user.php
+++ b/user.php
@@ -77,7 +77,6 @@ if ($config->settings->authModule == 'Y'){
 		list ($loginID,$restofAddr) = explode("@", $remoteAuth);
 
 
-
 		session_start();
 		$_SESSION['loginID'] = $loginID;
 


### PR DESCRIPTION
Hi all,
This is my first pull request, so please pardon my errors and feel free to critique.  I work at NCSU Libraries and we added some features to the routing tab for individual resources.  The short version is that you now will have the ability to delete steps and also to reassign steps to different groups.  Note: these changes will only affect the current resource.  The changes will not be saved as a workflow template and restarting the workflow, will reset it to the original template.

It's the end of the day, so I'm just going to throw this up here now for you to check out, and I can add notes tomorrow on some of the details involved in these new features.

I did most of this work a couple of months back, and only recently merged them in to the current version of CORAL.  As a result, there may be a few things that I do in a deprecated manner.  In particular I haven't had a chance to double check the way I did the database query or the resourcestepForm.js.  If you have a moment, will someone please look over these.  I'll try to find time tomorrow to go back over them.

Cheers,
Jason Raitz